### PR TITLE
docs: 前提/参照リンクをMarkdown化

### DIFF
--- a/docs/afterword/index.md
+++ b/docs/afterword/index.md
@@ -19,8 +19,8 @@ title: "あとがき"
 - 付録のテンプレ（チェックリスト/フロー）を起点に、ポストモーテムの学びを反映し続けることが、最も費用対効果の高い改善になります。
 
 ## 前提の再確認
-- 入門書（アプリ配置の基礎）: https://itdojp.github.io/kubernetes-basics-book/
+- 入門書（アプリ配置の基礎）: [Kubernetes入門：PodからIngressまで（基礎と実践）](https://itdojp.github.io/kubernetes-basics-book/)
 
 ## フィードバック
-- Issue: https://github.com/itdojp/kubernetes-cluster-ops-book/issues
+- Issue: [GitHub Issues](https://github.com/itdojp/kubernetes-cluster-ops-book/issues)
 - Email: knowledge@itdo.jp

--- a/docs/appendices/appendix-c/index.md
+++ b/docs/appendices/appendix-c/index.md
@@ -23,4 +23,4 @@ title: "付録C：参考リンク集"
 - Monitoring, Logging, and Debugging: https://kubernetes.io/docs/tasks/debug/
 
 ## 次に読む（前提）
-- Kubernetes入門：PodからIngressまで（基礎と実践）: https://itdojp.github.io/kubernetes-basics-book/
+- [Kubernetes入門：PodからIngressまで（基礎と実践）](https://itdojp.github.io/kubernetes-basics-book/)

--- a/docs/chapters/chapter00/index.md
+++ b/docs/chapters/chapter00/index.md
@@ -21,7 +21,7 @@ title: "第0章：前提とスコープ"
 
 ### 扱わない範囲
 - アプリ配置の基礎（Pod/Deployment/Service/Ingressの基本操作）
-  - 入門書: https://itdojp.github.io/kubernetes-basics-book/
+  - 入門書: [Kubernetes入門：PodからIngressまで（基礎と実践）](https://itdojp.github.io/kubernetes-basics-book/)
 - 個別ベンダの GUI 操作手順や、特定製品の詳細設定手順
 - すべての KEP/機能詳細の網羅
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,8 +13,8 @@ Kubernetes クラスタの設計・運用（責任範囲、HA、アップグレ�
 - 可用性、アップグレード、監視、障害対応の標準化を進めたい方
 
 ## 前提
-- 本書は「Kubernetes入門：PodからIngressまで（基礎と実践）」の理解を前提とします: https://itdojp.github.io/kubernetes-basics-book/
-- コンテナ基礎は必要に応じて Podman 本を参照します: https://itdojp.github.io/podman-book/
+- 本書は「Kubernetes入門：PodからIngressまで（基礎と実践）」の理解を前提とします: [Kubernetes入門：PodからIngressまで（基礎と実践）](https://itdojp.github.io/kubernetes-basics-book/)
+- コンテナ基礎は必要に応じて Podman 本を参照します: [Podman完全ガイド](https://itdojp.github.io/podman-book/)
 
 ## 目次
 - [はじめに](introduction/)

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -13,9 +13,9 @@ title: "はじめに"
 - 変更管理/復旧/セキュリティの観点で、運用の抜け漏れを減らす
 
 ## 前提（読者とスコープ）
-- 前提読了: Kubernetes入門：PodからIngressまで（基礎と実践）: https://itdojp.github.io/kubernetes-basics-book/
+- 前提読了: [Kubernetes入門：PodからIngressまで（基礎と実践）](https://itdojp.github.io/kubernetes-basics-book/)
 - 本書はアプリ配置の手順書ではなく、クラスタ運用の設計・標準化に焦点を当てます
-- コンテナ基礎は必要に応じて Podman 本を参照: https://itdojp.github.io/podman-book/
+- コンテナ基礎は必要に応じて Podman 本を参照: [Podman完全ガイド](https://itdojp.github.io/podman-book/)
 
 ## 対象環境（動作確認/想定）
 本書は特定ベンダに依存しませんが、議論の前提を揃えるため、以下を基準とします。
@@ -29,7 +29,7 @@ title: "はじめに"
 
 サポートポリシー（本書の前提）:
 - 本書は v1.35 系を基準とし、minor バージョン差分が設計/運用に影響する場合は注記します。
-- バージョン互換の考え方は、Kubernetes の Version Skew Policy を参照してください: https://kubernetes.io/releases/version-skew-policy/
+- バージョン互換の考え方は、Kubernetes の [Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/) を参照してください。
 
 ## 参照方針
 - 一次情報は Kubernetes/etcd の公式ドキュメントを優先します。
@@ -44,7 +44,7 @@ title: "はじめに"
 - 監視/ログ/復旧の三点セットを、全章の共通軸として扱います。
 
 ## フィードバック
-- Issue: https://github.com/itdojp/kubernetes-cluster-ops-book/issues
+- Issue: [GitHub Issues](https://github.com/itdojp/kubernetes-cluster-ops-book/issues)
 - Email: knowledge@itdo.jp
 
 ## 次に読む


### PR DESCRIPTION
## 変更内容
- 前提/参照に含まれるURLを Markdown リンク化し、本文の読みやすさを改善
- 公式文書参照（Version Skew Policy）とフィードバック導線（Issues）も同様にリンク整備

## 影響範囲
- 表記の整備のみで、章構成やURL（パス）は変更していません
