### PR TITLE
docs: 校正（トップページ補完）

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,7 +2,7 @@
 # Customize the values marked with <...>
 
 title: "Kubernetesクラスタ設計・運用実践ガイド"
-description: "Kubernetes クラスタの設計・運用（責任範囲、HA、アップグレード、監視、運用標準、障害対応）を中心に、実務観点で整理する。"
+description: "Kubernetes クラスタの設計・運用（責任範囲、HA、アップグレード、監視、運用標準、障害対応）を中心に、実務観点で整理します。"
 author: "株式会社アイティードゥ"
 version: "1.0.0"
 lang: "ja"

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,11 @@ Kubernetes クラスタの設計・運用（責任範囲、HA、アップグレ�
 - [付録B：トラブルシュートフロー集](appendices/appendix-b/)
 - [付録C：参考リンク集](appendices/appendix-c/)
 
+## あとがき
 - [あとがき](afterword/)
 
 ## ライセンス
 本書は CC BY-NC-SA 4.0 で公開されています。商用利用は別途契約が必要です。
+
+- シリーズ共通ライセンス: https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md
+- 本リポジトリ内: https://github.com/itdojp/kubernetes-cluster-ops-book/blob/main/LICENSE.md


### PR DESCRIPTION
目的
- トップページの情報量を、他書籍の標準（学習成果/所要時間/ライセンス）に合わせて補完する

変更内容
- `docs/index.md`
  - 冒頭文の文体を本文に合わせて調整
  - 学習成果/所要時間/ライセンスを追記

検証（ローカル）
- `node ../book-formatter/scripts/check-unicode.js docs --fail-on warn`
- `node ../book-formatter/scripts/check-textlint.js docs --fail-on error`
- `node ../book-formatter/scripts/check-links.js docs`
- `node ../book-formatter/scripts/check-layout-risk.js docs --fail-on error`
- `node ../book-formatter/scripts/check-markdown-structure.js docs --fail-on error`

いずれも PASS。
