### PR TITLE
chore: add npm security gate to Book QA

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -31,10 +31,18 @@ jobs:
         with:
           node-version: '20'
           cache: npm
-          cache-dependency-path: book-formatter/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            book-formatter/package-lock.json
 
-      - name: Metadata consistency check
-        run: npm run check:metadata
+      - name: Install local npm dependencies
+        run: npm ci
+
+      - name: Local npm security audit
+        run: npm run check:security
+
+      - name: Local npm QA
+        run: npm test
 
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 node_modules/
 dist/
 _site/
+.jekyll-cache/
+.jekyll-metadata
+.bundle/
+vendor/bundle/
+Gemfile.lock
+docs/_site/
+docs/.jekyll-cache/
+docs/.jekyll-metadata
 .DS_Store
 *.log

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Kubernetes クラスタの設計・運用（責任範囲、HA、アップグレ�
 ## 開発（ローカル）
 
 ### 前提
-- Node.js（動作確認: v22）
+- Node.js 20+（CI は Node.js 20 を使用）
 - npm
 
 ### セットアップ
 ```bash
-npm install
+npm ci
 ```
 
 ### src → docs 同期
@@ -34,6 +34,7 @@ npm run build
 ナビゲーション、`src/` との同期状態を確認します。
 
 ```bash
+npm run check:security
 npm run check:metadata
 npm test
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "sync": "node scripts/sync-src-to-docs.js",
     "build": "npm run sync && node scripts/node-build.js",
     "check:metadata": "node scripts/check-metadata-consistency.js",
+    "check:security": "npm audit",
     "test": "npm run check:metadata && npm run build",
     "serve": "cd dist && python3 -m http.server 4000 || python -m http.server 4000",
     "dev": "npm run build && npm run serve"


### PR DESCRIPTION
## Summary
- Audit-fix the existing lockfile by updating vulnerable `picomatch` from `2.3.1` to `2.3.2`.
- Add `npm run check:security` for `npm audit` and document it in the local QA flow.
- Run root `npm ci`, `npm run check:security`, and `npm test` in Book QA, and include `package-lock.json` in the npm cache key.
- Update README to prefer reproducible `npm ci` and Node.js 20+ to match CI.
- Ignore local Bundler/Jekyll artifacts produced during Pages verification.

## Scope note
- Existing open Issue #16 is about screenshot capture/insertion. This PR does not change screenshot content; it only improves the repository QA/security gate used by this quality sprint.

## Evidence
- Baseline `npm audit`: 1 high severity vulnerability in `picomatch <=2.3.1`.
- After `npm audit fix`: `npm run check:security` reports 0 vulnerabilities.
- Existing metadata gate already checks `src -> docs` synchronization before `npm test` runs the build.

## Local verification
- `npm ci`
- `npm run check:security`
- `npm run check:metadata`
- `npm test`
- Dist smoke: `dist/index.md`, `dist/chapters/chapter01/index.md`, `dist/chapters/chapter07/index.md`, `dist/chapters/chapter12/index.md`
- Workspace-local Bundler/Jekyll build: `bundle exec jekyll build --source docs --destination _site`
- Built HTML smoke: `_site/index.html`, `_site/chapters/chapter01/index.html`, `_site/chapters/chapter07/index.html`, `_site/chapters/chapter12/index.html`
- Workflow YAML parse for `.github/workflows/book-qa.yml`
- Pinned `book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4`: unicode, textlint, links, layout-risk, markdown-structure
- `git diff --check`