### PR TITLE
Fix mobile sidebar closed state

### DIFF
--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -53,8 +53,21 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * Keep the mobile drawer above the backdrop (`.book-sidebar-overlay` is
+     * 950) but below the fixed header (`.book-header` is 1000). This also
+     * needs to stay important so the later desktop `.book-sidebar` z-index in
+     * main.css cannot drop the mobile drawer behind the overlay.
+     */
+    z-index: 999 !important;
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 


### PR DESCRIPTION
## Summary
- keep the mobile/tablet sidebar closed state authoritative when `main.css` later declares the desktop sidebar transform
- keep the opened mobile drawer above the backdrop and below the fixed header

## Verification
- `npm ci`
- `npm run check:security`
- `npm test`
- `git diff --check`
- `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/kubernetes-cluster-ops-bundle-path BUNDLE_APP_CONFIG=/home/devuser/work/CodeX/booksB/.codex-local/tmp/kubernetes-cluster-ops-bundle-config bundle exec jekyll build --source docs --destination /home/devuser/work/CodeX/booksB/.codex-local/serve/kubernetes-cluster-ops-jekyll/kubernetes-cluster-ops-book`
- `node tools/pages-visual-check/run.mjs --registry .codex-local/kubernetes-cluster-ops-jekyll-registry.json --output .codex-local/issue168-kubernetes-cluster-ops-local-visual-jekyll --browsers chromium --viewports phone480,tablet,tablet820,laptop1024,desktop --onlyBooks kubernetes-cluster-ops-book --maxPagesPerBook 2 --concurrency 1 --skipScreenshots --enforceFontSpec`
- direct Playwright z-index probe for `/` and `/chapters/chapter01/` at 480/768/820/1024/1280 widths

Related: itdojp/it-engineer-knowledge-architecture#168
