### PR TITLE
fix: 公開内容にUX module metadataを合わせる

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -18,8 +18,8 @@
       "checklistPack": true,
       "troubleshootingFlow": true,
       "conceptMap": false,
-      "figureIndex": true,
-      "legalNotice": true,
+      "figureIndex": false,
+      "legalNotice": false,
       "glossary": false
     }
   },

--- a/book-formatter-config.json
+++ b/book-formatter-config.json
@@ -14,11 +14,11 @@
     "profile": "B",
     "modules": {
       "quickStart": false,
-      "readingGuide": false,
+      "readingGuide": true,
       "checklistPack": true,
       "troubleshootingFlow": true,
       "conceptMap": false,
-      "figureIndex": true,
+      "figureIndex": false,
       "legalNotice": false,
       "glossary": false
     }


### PR DESCRIPTION
## 概要

公開実態に合わせて`book-config.json`を補正します。

- `figureIndex`: `true` → `false`（reader-facingな専用図表索引なし）
- `legalNotice`: `true` → `false`（トップのライセンス節のみで、専用法的注意ページなし）

運用チェックリストとトラブルシュートフローは公開実体があるため変更しません。Profile Bの専用`figureIndex`不足はitdojp/it-engineer-knowledge-architecture#215で分離追跡します。

## 検証

- `npm ci`
- `npm test`
- `npm audit`（0 vulnerabilities）
- `git diff --check`

Closes #34
