### PR TITLE
ci: update Book QA formatter pin to cff9fcf8

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: itdojp/book-formatter
-          ref: 69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c
+          ref: cff9fcf8bae31140f07b358d314fc64173cb7013
           path: book-formatter
 
       - name: Setup Node.js


### PR DESCRIPTION
Closes #43

## Scope

This Draft PR updates the single active `itdojp/book-formatter` pin in `.github/workflows/book-qa.yml`:

`69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c` → `cff9fcf8bae31140f07b358d314fc64173cb7013`

The target was audited as immutable commit `cff9fcf8bae31140f07b358d314fc64173cb7013` (tree `43267c3672fb0df1919d667ea11cba8f1c704cb8`).

## Deliberately excluded

- Book content
- Consumer dependencies and lockfiles
- Build behavior and Pages configuration
- Repository settings

## Local verification

- Consumer `npm ci --ignore-scripts` and `npm audit --audit-level=high`: 0 vulnerabilities.
- Exact target formatter `npm ci --ignore-scripts` and `npm audit --audit-level=high`: 0 vulnerabilities.
- `npm test`, capture provenance, all target formatter checks, Pages-compatible Jekyll build/smoke, and `git diff --check`: passed.

Draft only: no Ready transition, review request, merge, rebase, force-push, main push, or settings change.

## Final exact-head gate

- Reviewed head: `70b7d339be51328978db5dc0ab56ebb664a94f9f`
- Book QA: https://github.com/itdojp/kubernetes-cluster-ops-book/actions/runs/32699349068 — success
- Diff: active `itdojp/book-formatter` immutable ref 1 line only
- Copilot review: completed; actionable inline/suggestion 0
- Codex exact-head review: no major issues
- Review completeness: unresolved / generated mismatch / missing review IDs = `0 / 0 / 0`
- Consumer audit high/critical: `0 / 0`
- Target formatter audit high/critical: `0 / 0`
- Merge method: normal squash only; no bypass, force push, rebase, or settings change
